### PR TITLE
travis-ci: update tarantool repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,13 @@ env:
       - OS=el DIST=7
       - OS=fedora DIST=26
       - OS=fedora DIST=27
+      - OS=fedora DIST=28
+      - OS=fedora DIST=29
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=artful
       - OS=ubuntu DIST=bionic
-      - OS=debian DIST=wheezy
+      - OS=ubuntu DIST=cosmic
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ env:
       - TARGET=test VERSION=1_7
       - TARGET=test VERSION=1_9
       - TARGET=test VERSION=1_10
-      - TARGET=test VERSION=2_0
+      - TARGET=test VERSION=2x
+      - TARGET=test VERSION=2_2
       - OS=el DIST=6
       - OS=el DIST=7
       - OS=fedora DIST=26

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,16 @@ deploy:
     on:
       branch: master
       condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_2"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
 
 notifications:
   email:

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=${VERSION:-2_0}
+VERSION=${VERSION:-2_2}
 
 curl https://packagecloud.io/tarantool/${VERSION}/gpgkey | sudo apt-key add -
 release=`lsb_release -c -s`


### PR DESCRIPTION
We have no 2_0 repository anymore, but now there are 2x (with 2.0 and
2.1 versions) and 2_2 ones.